### PR TITLE
Explicitly #include <limits> to ems.cpp for compatibility with GCC 11+

### DIFF
--- a/source/ems.cpp
+++ b/source/ems.cpp
@@ -19,6 +19,7 @@
 
 #include "ems.hpp"
 
+#include <limits>
 #include <tinyxml2.h>
 #include <sstream>
 #include <iostream>


### PR DESCRIPTION
This fixes the problem referenced in issue #13 .